### PR TITLE
Add rate limit to bridging

### DIFF
--- a/script/DeployGydL1CCIPEscrow.s.sol
+++ b/script/DeployGydL1CCIPEscrow.s.sol
@@ -38,6 +38,10 @@ contract DeployGydL1CCIPEscrow is Script {
 
   uint256 gasLimit = 200_000; // max 200k gas to complete the bridging
 
+  uint256 capacity = 100_000; // max 100k GYD at once
+
+  uint256 refillRate = 10; // 1 GYD per second
+
   // CREATE3 Factory
   ICREATE3Factory factory =
     ICREATE3Factory(0x93FEC2C00BfE902F733B57c5a6CeeD7CD1384AE1);
@@ -60,7 +64,9 @@ contract DeployGydL1CCIPEscrow is Script {
       chainSelector: arbitrumChainSelector,
       metadata: IGydBridge.ChainMetadata({
         targetAddress: l2Address,
-        gasLimit: gasLimit
+        gasLimit: gasLimit,
+        capacity: capacity,
+        refillRate: refillRate
       })
     });
 

--- a/src/IGydBridge.sol
+++ b/src/IGydBridge.sol
@@ -5,6 +5,8 @@ interface IGydBridge {
   struct ChainMetadata {
     address targetAddress;
     uint256 gasLimit;
+    uint256 capacity;
+    uint256 refillRate;
   }
 
   struct ChainData {
@@ -12,12 +14,13 @@ interface IGydBridge {
     ChainMetadata metadata;
   }
 
-  /// @notice This event is emitted when a new chain is added
-  event ChainAdded(
-    uint64 indexed chainSelector,
-    address indexed targetAddress,
-    uint256 gasLimit
-  );
+  struct RateLimitData {
+    uint192 available;
+    uint64 lastRefill;
+  }
+
+  /// @notice This event is emitted when a new chain is set
+  event ChainSet(uint64 indexed chainSelector, ChainMetadata metadata);
 
   /// @notice This event is emitted when the gas limit is updated
   event GasLimitUpdated(uint64 indexed chainSelector, uint256 gasLimit);
@@ -46,4 +49,9 @@ interface IGydBridge {
 
   /// @notice This error is raised if the msg value is not enough for the fees
   error FeesNotCovered(uint256 fees);
+
+  /// @notice This error is raised if the rate limit is exceeded
+  error RateLimitExceeded(
+    uint64 chainSelector, uint256 requested, uint256 available
+  );
 }


### PR DESCRIPTION
Add rate limit to bridging. This uses a model similar to Chainlink where each "lane" has a maximum capacity that refills at a certain speed.
We'll need to decide on the capacity and the refill speed.